### PR TITLE
added optional parameter 'include_drums' to pianoroll

### DIFF
--- a/pretty_midi/instrument.py
+++ b/pretty_midi/instrument.py
@@ -74,7 +74,7 @@ class Instrument(object):
         return np.sort(onsets)
 
     def get_piano_roll(self, fs=100, times=None,
-                       pedal_threshold=64):
+                       pedal_threshold=64,include_drums=False):
         """Compute a piano roll matrix of this instrument.
 
         Parameters
@@ -109,7 +109,7 @@ class Instrument(object):
         # Allocate a matrix of zeros - we will add in as we go
         piano_roll = np.zeros((128, int(fs*end_time)))
         # Drum tracks don't have pitch, so return a matrix of zeros
-        if self.is_drum:
+        if self.is_drum and not include_drums:
             if times is None:
                 return piano_roll
             else:


### PR DESCRIPTION
to allow the return of a meaningful pianoroll for drum instruments too (pitch is the selected instrument in this case).
This was disabled since the values do not fit into a classic pianoroll.
However when used to preprocess midi files for machine learning, this can be useful.